### PR TITLE
Add support for org-reveal to org layer

### DIFF
--- a/layers/org/README.org
+++ b/layers/org/README.org
@@ -11,6 +11,7 @@
    - [[Layer][Layer]]
    - [[Github support][Github support]]
    - [[Gnuplot support][Gnuplot support]]
+   - [[Reveal.js support][Reveal.js support]]
    - [[Different bullets][Different bullets]]
  - [[Key bindings][Key bindings]]
    - [[Org][Org]]
@@ -79,6 +80,26 @@ demonstrated [[http://orgmode.org/worg/org-tutorials/org-plot.html][here]]; unfo
 at this stage.  It is possible to disable the configuration of gnuplot support
 as usual by adding the package =gnuplot= to your =dotspacemacs-excluded-packages=
 variable.
+
+** Reveal.js support
+
+To enable the export of your org file as a [[http://lab.hakim.se/reveal-js/][reveal.js]] presentation, set the
+variable =org-enable-reveal-js= to =t=. This will install the [[https://github.com/yjwen/org-reveal/][org-reveal]] extension.
+
+#+BEGIN_SRC emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(
+    (org :variables
+         org-enable-reveal-js t)))
+#+END_SRC
+
+In order to be able to use org-reveal, download =reveal.js= from its
+[[http://lab.hakim.se/reveal-js/#/][homepage]] and set =org-reveal-js= to the
+download path, as described in the [[https://github.com/yjwen/org-reveal#obtain-revealjs][manual]]. Alternatively, add the following line
+to each =.org= file you want to process:
+
+#+BEGIN_EXAMPLE
+#+REVEAL_ROOT: http://cdn.jsdelivr.net/reveal.js/3.0.0/
+#+END_EXAMPLE
 
 ** Different bullets
 You can tweak the bullets displayed in the org buffer in the function

--- a/layers/org/config.el
+++ b/layers/org/config.el
@@ -15,4 +15,7 @@
 (defvar org-enable-github-support nil
   "If non-nil Github related packages are configured.")
 
+(defvar org-enable-reveal-js nil
+  "If non-nil, enables ox-reveal export.")
+
 (spacemacs|defvar-company-backends org-mode)

--- a/layers/org/packages.el
+++ b/layers/org/packages.el
@@ -31,6 +31,7 @@
     org-repo-todo
     persp-mode
     toc-org
+    ox-reveal
     ))
 
 (when (configuration-layer/layer-usedp 'auto-completion)
@@ -385,6 +386,9 @@ Will work on both org-mode and any mode that accepts plain html."
       (setq toc-org-max-depth 10)
       (add-hook 'org-mode-hook 'toc-org-enable))))
 
+(defun org/init-ox-reveal ()
+  (use-package ox-reveal
+    :if org-enable-reveal-js))
 (defun org/init-htmlize ()
  (use-package htmlize
     :defer t))


### PR DESCRIPTION
Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3
org-reveal is an extension to org mode that allows exporting of org files as
reveal.js presentations. Since not everyone needs this functionality, the
loading of the package is controlled via the `org-enable-reveal-js` switch,
which, if set to `t` would load the package.